### PR TITLE
Add Jekyll index page with bilingual site overview

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,36 @@
+---
+layout: default
+title: MMSXX samples
+---
+
+<h1>MMSXX Samples</h1>
+
+<section>
+  <h2>Overview (English)</h2>
+  <p>This site distributes works, assets, and materials created with homemade MSX-related tools.</p>
+  <p>All downloads are provided under the <a href="https://creativecommons.org/licenses/by/4.0/deed.en">Creative Commons Attribution 4.0 International (CC BY 4.0)</a> license.</p>
+  <ul>
+    <li>Author: harayoki</li>
+    <li>Quoting on social media or other minor non-commercial uses are fine even without attribution.</li>
+    <li>For commercial use or redistribution, please follow CC BY and credit the author name or link to this site.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>概要（日本語）</h2>
+  <p>このサイトではMSX関連の自作ツールで作った作品・アセットや素材を配布します。</p>
+  <p>すべてのダウンロードは<a href="https://creativecommons.org/licenses/by/4.0/deed.ja">Creative Commons Attribution 4.0 International（CC BY 4.0）</a>で提供します。</p>
+  <ul>
+    <li>著作者：harayoki</li>
+    <li>SNSでの引用や非商用の軽微な利用では、著作者表記がなくても問題ありません。</li>
+    <li>商用利用・再配布では CC BY に従い、著作者名または当サイトへのリンクを明記してください。</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Downloads</h2>
+  <ul>
+    <li><a href="{{ '/rom/' | relative_url }}">ROM files</a></li>
+    <li><a href="{{ '/dsk/' | relative_url }}">DSK images</a></li>
+  </ul>
+</section>


### PR DESCRIPTION
## Summary
- create a Jekyll index page that mirrors the repository overview in English and Japanese
- include CC BY 4.0 license details and author attribution consistent with the README
- add download links to the ROM and DSK subfolders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930ee748b2883248ffe5f7fc727f056)