### PR TITLE
Update media links to use configured base URL

### DIFF
--- a/docs/_layouts/folder_index.html
+++ b/docs/_layouts/folder_index.html
@@ -58,8 +58,12 @@ layout: default
         </li>
 
       {% elsif ext == '.mp4' or ext == '.mp3' %}
+        {% assign media_url = lfs_base | append: f.path %}
         <li>
-          <a href="{{ f.path | relative_url }}">{{ f.name }}</a><br>
+          <a href="{{ media_url }}">{{ f.name }}</a><br>
+          {% if ext == '.mp4' %}
+            <video src="{{ media_url }}" controls style="max-width:50%; height:auto;"></video><br>
+          {% endif %}
           {% if desc %}<small>{{ desc }}</small>{% endif %}
         </li>
 


### PR DESCRIPTION
## Summary
- use the configured media base URL for video and audio links
- render mp4 previews using the raw media URL so large files load from the media host

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311617cd888324a253480786848fac)