### PR TITLE
Fix folder index pages to use page directories

### DIFF
--- a/docs/dsk/index.html
+++ b/docs/dsk/index.html
@@ -1,5 +1,4 @@
 ---
 layout: folder_index
 title: sample folder
-target_path: "/sample/"
 ---

--- a/docs/movie/index.html
+++ b/docs/movie/index.html
@@ -1,5 +1,4 @@
 ---
 layout: folder_index
 title: sample folder
-target_path: "/sample/"
 ---

--- a/docs/pics/index.html
+++ b/docs/pics/index.html
@@ -1,5 +1,4 @@
 ---
 layout: folder_index
 title: sample folder
-target_path: "/sample/"
 ---

--- a/docs/pics/sample_images_2512_1/index.html
+++ b/docs/pics/sample_images_2512_1/index.html
@@ -1,7 +1,6 @@
 ---
 layout: folder_index
 title: sample folder
-target_path: "/sample/"
 
 descriptions:
   saru.png: "おサル画像。"

--- a/docs/rom/index.html
+++ b/docs/rom/index.html
@@ -1,5 +1,4 @@
 ---
 layout: folder_index
 title: sample folder
-target_path: "/sample/"
 ---


### PR DESCRIPTION
## Summary
- remove incorrect target_path overrides from folder index pages so listings use the page directory
- ensure nested picture sample index also relies on its own directory for listing files

## Testing
- not run (static site change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693118d25d6c83249288d554c8ae94fe)