### PR TITLE
Add docs _config to expose site variables

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,2 @@
+baseurl: "/MMSXX_samples"
+lfs_media_base: "https://media.githubusercontent.com/media/harayoki/MMSXX_samples/main/docs"


### PR DESCRIPTION
## Summary
- add a docs-level _config.yml so templates can read the configured site variables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a196d5c48324a8deb944cb693fe5)