### PR TITLE
Fix parent directory slicing in index layouts

### DIFF
--- a/docs/_layouts/folder_index.html
+++ b/docs/_layouts/folder_index.html
@@ -8,7 +8,8 @@ layout: default
 
 <!-- Parent directory link -->
 {% assign parts = target_path | split:'/' %}
-{% assign parent_parts = parts | slice: 0, parts.size-2 %}
+{% assign parent_length = parts.size | minus: 2 %}
+{% assign parent_parts = parts | slice: 0, parent_length %}
 {% assign parent_path = parent_parts | join:'/' | append:'/' %}
 <p><a href="{{ parent_path | relative_url }}">Parent directory</a></p>
 

--- a/docs/_layouts/picture_index.html
+++ b/docs/_layouts/picture_index.html
@@ -8,7 +8,8 @@ layout: default
 
 <!-- Parent directory link -->
 {% assign parts = target_path | split:'/' %}
-{% assign parent_parts = parts | slice: 0, parts.size-2 %}
+{% assign parent_length = parts.size | minus: 2 %}
+{% assign parent_parts = parts | slice: 0, parent_length %}
 {% assign parent_path = parent_parts | join:'/' | append:'/' %}
 <p><a href="{{ parent_path | relative_url }}">Parent directory</a></p>
 


### PR DESCRIPTION
## Summary
- calculate the parent slice length using Liquid's minus filter before slicing path parts
- use the computed length to build parent directory links in both index layouts

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b36ade148324bf052db08fca9d2c)