### PR TITLE
Show folder descriptions under index titles

### DIFF
--- a/docs/_layouts/folder_index.html
+++ b/docs/_layouts/folder_index.html
@@ -5,6 +5,9 @@ layout: default
 {% assign target_path = page.target_path | default: page.dir %}
 
 <h2>{{ page.title }}</h2>
+{% if page.folder_description %}
+  <p>{{ page.folder_description }}</p>
+{% endif %}
 
 <!-- Parent directory link -->
 {% assign parts = target_path | split:'/' %}

--- a/docs/_layouts/picture_index.html
+++ b/docs/_layouts/picture_index.html
@@ -5,6 +5,9 @@ layout: default
 {% assign target_path = page.target_path | default: page.dir %}
 
 <h2>{{ page.title }}</h2>
+{% if page.folder_description %}
+  <p>{{ page.folder_description }}</p>
+{% endif %}
 
 <!-- Parent directory link -->
 {% assign parts = target_path | split:'/' %}

--- a/docs/pics/AI_S12_images_202512/index.html
+++ b/docs/pics/AI_S12_images_202512/index.html
@@ -1,4 +1,5 @@
 ---
 layout: picture_index
-title: screen 12 YJK Pictures converted by AI (https://codeberg.org/randysimons/msx-screen12-ai-image-converter)
+title: screen 12 YJK Pictures converted by AI 
+folder_description: @see https://codeberg.org/randysimons/msx-screen12-ai-image-converter
 ---


### PR DESCRIPTION
## Summary
- render optional folder descriptions beneath page titles in folder and picture index layouts

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f6140ddc8324bb9f903874bb8025)